### PR TITLE
Typo in documentation and demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ to the ```require``` section of your `composer.json` file.
 
 ## Demo
 
-You can refer detailed [documentation and demos](http://demos.krajee.com/widget-details/switchinputinput) on usage of the extension.
+You can refer detailed [documentation and demos](http://demos.krajee.com/widget-details/switchinput) on usage of the extension.
 
 ## Usage
 


### PR DESCRIPTION
There was a typo in the documentation and demos link
